### PR TITLE
Add modeling realm to json table name

### DIFF
--- a/scripts/init_conform
+++ b/scripts/init_conform
@@ -267,7 +267,8 @@ def create_output(exp_dict, definitions, attributes, output_path, args, experime
         for v,d in variables.iteritems():
             if v in definitions.keys():
                 var_list[v] = defineVar(d, v, attributes, definitions[v], experiment)
-                ts_key = var_list[v]["file"]["attributes"]["activity_id"]+'_'+var_list[v]["attributes"]["mipTable"]
+                realm = d["realm"].replace(' ','_')
+                ts_key = var_list[v]["file"]["attributes"]["activity_id"]+'_'+var_list[v]["attributes"]["mipTable"]+'_'+realm
                 if ts_key not in TableSpec.keys():
                     TableSpec[ts_key] = {}
                 TableSpec[ts_key][v] = var_list[v]


### PR DESCRIPTION
- This is needed because we want to make sure we're passing the correct
  model data to PyConform.  For example, the Amon table requests both
  atm and lnd data and we want to make sure we grab the correct temp
  variable based on the modeling realm.  A separate atm_Amon and lnd_Amon
  will ensure we're passing the correct data.