### PR TITLE
Adding feature to autoparse filenames

### DIFF
--- a/source/pyconform/dataflow.py
+++ b/source/pyconform/dataflow.py
@@ -257,7 +257,8 @@ class DataFlow(object):
                      '{}'.format(fname, ', '.join(sorted(vmissing))), DefinitionWarning)
             else:
                 vnodes = tuple(valnodes[vname] for vname in fdesc.variables)
-                writenodes[fname] = WriteNode(fdesc, inputs=vnodes)
+                wnode = WriteNode(fdesc, inputs=vnodes)
+                writenodes[wnode.label] = wnode
         return writenodes
 
     def _compute_variable_sizes_(self, valnodes):

--- a/source/pyconform/flownodes.py
+++ b/source/pyconform/flownodes.py
@@ -625,7 +625,9 @@ class WriteNode(FlowNode):
                                   'contained in the descibed file').format(filedesc.name, inp.label))
 
         # Construct the proper filename
-        self._label = self._autoparse_filename_(self.label)
+        fname = self._autoparse_filename_(self.label)
+        self._label = fname
+        self._filedesc._name = fname
         
         # Set the filehandle
         self._file = None

--- a/source/pyconform/physarray.py
+++ b/source/pyconform/physarray.py
@@ -466,7 +466,6 @@ class PhysArray(numpy.ma.MaskedArray):
         return other
 
     def __mul__(self, other):
-        print self.data, self.mask, self._optinfo
         result = PhysArray(self)
         other = result._mul_div_init_(other)
         return PhysArray(super(PhysArray, result).__mul__(other), name='({}*{})'.format(result.name, other.name),

--- a/source/pyconform/physarray.py
+++ b/source/pyconform/physarray.py
@@ -153,14 +153,15 @@ class PhysArray(numpy.ma.MaskedArray):
     along the edges of a Data Flow graph.
     """
 
-    def __new__(cls, indata, mask=None, name=None, units=None, dimensions=None, positive=''):
-        obj = numpy.ma.asarray(indata).view(cls)
+    def __new__(cls, indata, name=None, units=None, dimensions=None, positive='', **kwds):
+        makwds = {k:kwds[k] for k in ['dtype'] if k in kwds}
+        obj = numpy.ma.asarray(indata, **makwds).view(cls)
         if obj.dtype.char in ('S', 'U'):
             return CharArray(indata, name=name, dimensions=dimensions)
         
         # Add the mask if specified
-        if mask is not None:
-            obj.mask = mask
+        if 'mask' in kwds:
+            obj.mask = kwds['mask']
 
         # Store a name associated with the object
         if name is None:
@@ -565,34 +566,54 @@ class PhysArray(numpy.ma.MaskedArray):
         self.positive = None if other.data % 2 == 0 else self.positive
         return self
 
-    def mean(self, dimensions=None):
+    def mean(self, dimensions=None, **kwds):
         if dimensions is None:
+            axis = kwds['axis'] if 'axis' in kwds else None
+        elif isinstance(dimensions, (list, tuple)):
+            axis = tuple(i for i in sorted(self.dimensions.index(d) for d in dimensions))
+        else:
+            raise TypeError('Dimensions must be given as a list or tuple')
+        if axis is None:
             dims = self.dimensions
             meanval = self.view(numpy.ma.MaskedArray).mean()
-        else:
-            dims = dimensions
+        elif isinstance(axis, int):
+            dims = (self.dimensions[axis],)
+            meanval = self.view(numpy.ma.MaskedArray).mean(axis=axis)
+        elif isinstance(axis, (list, tuple)):
+            dims = tuple(self.dimensions[i] for i in axis)
             meanval = self.view(numpy.ma.MaskedArray)
-            axes = tuple(i-n for n,i in enumerate(sorted(self.dimensions.index(d) for d in dims)))
-            for axis in axes:
-                meanval = meanval.mean(axis=axis)
+            for a in axis:
+                meanval = meanval.mean(axis=a)
+        else:
+            raise TypeError('Axis must be given as an integer, list or tuple')
         new_dims = tuple(d for d in self.dimensions if d not in dims)
         dim_str = ','.join(str(d) for d in dims)
         return PhysArray(meanval, name='mean({}, dims=[{}])'.format(self.name, dim_str), dimensions=new_dims,
                          positive=self.positive, units=self.units)
 
-    def sum(self, dimensions=None):
+    def sum(self, dimensions=None, **kwds):
         if dimensions is None:
-            dims = self.dimensions
-            meanval = self.view(numpy.ma.MaskedArray).mean()
+            axis = kwds['axis'] if 'axis' in kwds else None
+        elif isinstance(dimensions, (list, tuple)):
+            axis = tuple(i for i in sorted(self.dimensions.index(d) for d in dimensions))
         else:
-            dims = dimensions
-            meanval = self.view(numpy.ma.MaskedArray)
-            axes = tuple(i-n for n,i in enumerate(sorted(self.dimensions.index(d) for d in dims)))
-            for axis in axes:
-                meanval = meanval.mean(axis=axis)
+            raise TypeError('Dimensions must be given as a list or tuple')
+        if axis is None:
+            dims = self.dimensions
+            sumval = self.view(numpy.ma.MaskedArray).sum()
+        elif isinstance(axis, int):
+            dims = (self.dimensions[axis],)
+            sumval = self.view(numpy.ma.MaskedArray).sum(axis=axis)
+        elif isinstance(axis, (list, tuple)):
+            dims = tuple(self.dimensions[i] for i in axis)
+            sumval = self.view(numpy.ma.MaskedArray)
+            for a in axis:
+                sumval = sumval.mean(axis=a)
+        else:
+            raise TypeError('Axis must be given as an integer, list or tuple')
         new_dims = tuple(d for d in self.dimensions if d not in dims)
         dim_str = ','.join(str(d) for d in dims)
-        return PhysArray(meanval, name='sum({}, dims=[{}])'.format(self.name, dim_str), dimensions=new_dims,
+        return PhysArray(sumval, name='sum({}, dims=[{}])'.format(self.name, dim_str), dimensions=new_dims,
                          positive=self.positive, units=self.units)
         
 

--- a/source/pyconform/test/dataflowTests.py
+++ b/source/pyconform/test/dataflowTests.py
@@ -214,7 +214,7 @@ class DataFlowTests(unittest.TestCase):
         vattribs['standard_name'] = 'transposed u1'
         vattribs['units'] = 'km'
         vattribs['valid_min'] = 1.0
-        vattribs['valid_max'] = 20.0
+        vattribs['valid_max'] = 200.0
         vdicts['V4']['attributes'] = vattribs
         
         vdicts['V5'] = OrderedDict()
@@ -228,8 +228,8 @@ class DataFlowTests(unittest.TestCase):
         vattribs = OrderedDict()
         vattribs['standard_name'] = 'mean of u1 along the lon dimension'
         vattribs['units'] = 'km'
-        vattribs['valid_min'] = 1.0
-        vattribs['valid_max'] = 20.0
+        vattribs['valid_min'] = 5.0
+        vattribs['valid_max'] = 220.0
         vdicts['V5']['attributes'] = vattribs
 
         vdicts['V6'] = OrderedDict()
@@ -243,8 +243,8 @@ class DataFlowTests(unittest.TestCase):
         vattribs = OrderedDict()
         vattribs['standard_name'] = 'u2 at lowest x-level'
         vattribs['units'] = 'km'
-        vattribs['valid_min'] = 1.0
-        vattribs['valid_max'] = 20.0
+        vattribs['valid_min'] = 0.01
+        vattribs['valid_max'] = 0.2
         vdicts['V6']['attributes'] = vattribs
 
         vdicts['V7'] = OrderedDict()
@@ -258,8 +258,8 @@ class DataFlowTests(unittest.TestCase):
         vattribs = OrderedDict()
         vattribs['standard_name'] = 'u2 in upward direction'
         vattribs['units'] = 'm'
-        vattribs['valid_min'] = 1.0
-        vattribs['valid_max'] = 20.0
+        vattribs['valid_min'] = -200.0
+        vattribs['valid_max'] = 0.0
         vattribs['positive'] = 'up'
         vdicts['V7']['attributes'] = vattribs
 
@@ -274,8 +274,8 @@ class DataFlowTests(unittest.TestCase):
         vattribs = OrderedDict()
         vattribs['standard_name'] = 'u3 in upward direction'
         vattribs['units'] = 'kg'
-        vattribs['valid_min'] = 1.0
-        vattribs['valid_max'] = 20.0
+        vattribs['valid_min'] = -200.0
+        vattribs['valid_max'] = -1.0
         vattribs['positive'] = 'up'
         vdicts['V8']['attributes'] = vattribs
         

--- a/source/pyconform/test/dataflowTests.py
+++ b/source/pyconform/test/dataflowTests.py
@@ -16,9 +16,9 @@ import unittest
 import numpy
 
 
-#===================================================================================================
+#=======================================================================================================================
 # DataFlowTests
-#===================================================================================================
+#=======================================================================================================================
 class DataFlowTests(unittest.TestCase):
     """
     Unit tests for the flownodes.FlowNode class
@@ -164,7 +164,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V1']['dimensions'] = ('t', 'y', 'x')
         vdicts['V1']['definition'] = '0.5*(u1 + u2)'
         fdict = OrderedDict()
-        fdict['filename'] = 'var1.nc'
+        fdict['filename'] = 'var1_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V1'}
         fdict['metavars'] = ['L', 'C']
         vdicts['V1']['file'] = fdict
@@ -178,7 +178,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V2']['dimensions'] = ('t', 'y', 'x')
         vdicts['V2']['definition'] = 'u2 - u1'
         fdict = OrderedDict()
-        fdict['filename'] = 'var2.nc'
+        fdict['filename'] = 'var2_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V2'}
         fdict['metavars'] = ['L', 'B']
         vdicts['V2']['file'] = fdict
@@ -192,7 +192,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V3']['dimensions'] = ('x', 'y', 't')
         vdicts['V3']['definition'] = 'u2'
         fdict = OrderedDict()
-        fdict['filename'] = 'var3.nc'
+        fdict['filename'] = 'var3_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V3'}
         fdict['metavars'] = ['L']
         vdicts['V3']['file'] = fdict
@@ -206,7 +206,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V4']['dimensions'] = ('t', 'x', 'y')
         vdicts['V4']['definition'] = 'u1'
         fdict = OrderedDict()
-        fdict['filename'] = 'var4.nc'
+        fdict['filename'] = 'var4_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V4'}
         fdict['metavars'] = ['L']
         vdicts['V4']['file'] = fdict
@@ -222,7 +222,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V5']['dimensions'] = ('t', 'y')
         vdicts['V5']['definition'] = 'mean(u1, "lon")'
         fdict = OrderedDict()
-        fdict['filename'] = 'var5.nc'
+        fdict['filename'] = 'var5_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V5'}
         vdicts['V5']['file'] = fdict
         vattribs = OrderedDict()
@@ -237,7 +237,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V6']['dimensions'] = ('t', 'y')
         vdicts['V6']['definition'] = 'u2[:,:,0]'
         fdict = OrderedDict()
-        fdict['filename'] = 'var6.nc'
+        fdict['filename'] = 'var6_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V6'}
         vdicts['V6']['file'] = fdict
         vattribs = OrderedDict()
@@ -252,7 +252,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V7']['dimensions'] = ('t', 'x', 'y')
         vdicts['V7']['definition'] = 'down(u2)'
         fdict = OrderedDict()
-        fdict['filename'] = 'var7.nc'
+        fdict['filename'] = 'var7_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V7'}
         vdicts['V7']['file'] = fdict
         vattribs = OrderedDict()
@@ -268,7 +268,7 @@ class DataFlowTests(unittest.TestCase):
         vdicts['V8']['dimensions'] = ('t', 'x', 'y')
         vdicts['V8']['definition'] = 'u3'
         fdict = OrderedDict()
-        fdict['filename'] = 'var8.nc'
+        fdict['filename'] = 'var8_{%Y%m%d-%Y%m%d}.nc'
         fdict['attributes'] = {'variable': 'V8'}
         vdicts['V8']['file'] = fdict
         vattribs = OrderedDict()
@@ -283,8 +283,8 @@ class DataFlowTests(unittest.TestCase):
 
         self.outds = datasets.OutputDatasetDesc('outds', self.dsdict)
 
-        self.outfiles = dict((vname, vdict['file']['filename']) for vname, vdict
-                             in vdicts.iteritems() if 'file' in vdict)
+        self.outfiles = dict((vname, vdict['file']['filename'].replace('{%Y%m%d-%Y%m%d}', '19790101-19790104'))
+                             for vname, vdict in vdicts.iteritems() if 'file' in vdict)
         self.cleanOutputFiles()
 
     def cleanInputFiles(self):

--- a/source/pyconform/test/flownodesTests.py
+++ b/source/pyconform/test/flownodesTests.py
@@ -567,8 +567,7 @@ class ValidateNodeTests(unittest.TestCase):
         self.assertEqual(actual.dimensions, expected.dimensions, '{} failed'.format(testname))
         
     def test_time_units_error_calendar(self):
-        N0 = DataNode(PhysArray(numpy.arange(10), name='x', units='days since 2000-01-01 00:00:00',
-                                dimensions=('x',)))
+        N0 = DataNode(PhysArray(numpy.arange(10), name='x', units='days since 2000-01-01 00:00:00', dimensions=('x',)))
         indata = {'units': 'days since 2000-01-01 00:00:00', 'calendar': 'noleap'}
         testname = ('WARN: ValidateNode({}).__getitem__(:)'
                     '').format(', '.join('{!s}={!r}'.format(k, v) for k, v in indata.iteritems()))

--- a/source/pyconform/test/testutils.py
+++ b/source/pyconform/test/testutils.py
@@ -7,7 +7,7 @@ LICENSE: See the LICENSE.rst file for details
 
 from re import sub
 from os import linesep
-from numpy import array_str, dtype
+from numpy import dtype
 from netCDF4 import Dataset
 
 #=======================================================================================================================
@@ -47,7 +47,7 @@ def print_ncfile(filename):
             vdat = vobj[:]
             if vobj.dtype == dtype('c'):
                 vdat = vdat.data.view('S{}'.format(vdat.shape[-1])).reshape(vdat.shape[:-1])
-            datastr = array_str(vdat, max_line_width=10000).replace('\n', '\n{}'.format(' ' * len(header)))
+            datastr = str(vdat).replace('\n', '\n{}'.format(' ' * len(header)))
             print '{}{}'.format(header, datastr)
             for vattr in vobj.ncattrs():
                 print '         {}: {}'.format(vattr, vobj.getncattr(vattr))


### PR DESCRIPTION
Allows for the syntax: {%Y%m%d-%Y%m%d} in output filenames, which will be parsed using the time-data written to the file.